### PR TITLE
Add Support for Deploy to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -24,45 +24,43 @@ An example of meteor-multi-deploy.json
   "platforms": [
     {
       "platformName": "heroku",
-      "projectName": "meteor-multi-deploy-setup-production",
+      "projectName": "app-production",
       "environment": "production",
       "settingsFilePath": "settings-production.json"
     },
     {
       "platformName": "heroku",
-      "projectName": "meteor-multi-deploy-setup-staging",
+      "projectName": "app-staging",
       "environment": "staging",
-      "branchToPush": "staging",
-      "confirmPushToMaster": "true",
       "settingsFilePath": "settings-staging.json"
     },
     {
       "platformName":     "modulus",
       "environment":      "production",
-      "projectName":      "hoopla-production",
+      "projectName":      "app-production",
       "settingsFilePath": "settings-production.json"
     },
     {
       "platformName":     "modulus",
       "environment":      "staging",
-      "projectName":      "hoopla-staging",
+      "projectName":      "app-staging",
       "settingsFilePath": "settings-staging.json"
     },
     {
       "platformName":           "android",
       "environment":            "production",
-      "projectName":            "hoopla.keystore",
-      "server":                 "app.hoopla.social",
-      "storepass":              "hoopla",
+      "projectName":            "app.keystore",
+      "server":                 "app.app.social",
+      "storepass":              "app",
       "keystoreFilePath":       ".keystore",
       "mobileSettingsFilePath": "settings-production.json",
-      "apkOutputPath":          "~/Downloads/hoopla.apk"
+      "apkOutputPath":          "~/Downloads/app.apk"
     },
     {
       "platformName":           "ios",
       "environment":            "production",
-      "projectName":            "hoopla",
-      "server":                 "app.hoopla.social",
+      "projectName":            "app",
+      "server":                 "app.app.social",
       "mobileSettingsFilePath": "settings-production.json"
     }
   ]
@@ -85,10 +83,6 @@ An example of meteor-multi-deploy.json
 ### parameters
 - projectName
 - (OPTIONAL) settingsFilePath
-
-#### If not pushing to production and the master branch, please confirm which branch to push
-- branchToPush
-- confirmPushToMaster
 
 ## modulus
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ An example of meteor-multi-deploy.json
 {
   "platforms": [
     {
+      "platformName": "heroku",
+      "projectName": "meteor-multi-deploy-setup-production",
+      "environment": "production",
+      "settingsFilePath": "settings-production.json"
+    },
+    {
+      "platformName": "heroku",
+      "projectName": "meteor-multi-deploy-setup-staging",
+      "environment": "staging",
+      "branchToPush": "staging",
+      "confirmPushToMaster": "true",
+      "settingsFilePath": "settings-staging.json"
+    },
+    {
       "platformName":     "modulus",
       "environment":      "production",
       "projectName":      "hoopla-production",
@@ -65,6 +79,16 @@ An example of meteor-multi-deploy.json
     (You can ignore the current platform when trying to deploy)
 
 # Platforms<a name="platforms"></a>
+
+## heroku
+
+### parameters
+- projectName
+- (OPTIONAL) settingsFilePath
+
+#### If not pushing to production and the master branch, please confirm which branch to push
+- branchToPush
+- confirmPushToMaster
 
 ## modulus
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # The Goal
 Automate the deployment of a meteor project to multiple platforms.
 
+# Requirements
+node >= 6.0.0
+
 # Note
 This is package is only tested on Mac.
 
 # Get Started
 ```
 npm install -g meteor-multi-deploy
-alias mmd="meteor-multi-deploy"
 ```
 
-After creating a meteor-multi-deploy.json under your meteor directory,
-you can use ***meteor-multi-deploy(mmd)*** to deploy to multiple platforms.
 ```
 mmd # deploy to all platforms specified in the json file
 mmd android # only deploy to android
@@ -64,7 +64,7 @@ An example of meteor-multi-deploy.json
       "projectName":            "hoopla",
       "server":                 "app.hoopla.social",
       "mobileSettingsFilePath": "settings-production.json"
-    },
+    }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ An example of meteor-multi-deploy.json
 Publish your apk file at https://play.google.com/apps/publish
 
 # TODO
+- mmd init project-name (create default meteor-multi-deploy file)
+- after the above, merge mmd into stanza
 - add a walk through like what npm does
 - change mobile settings to settings, unify the api
 - for development, enable ios device

--- a/lib/platforms/heroku.js
+++ b/lib/platforms/heroku.js
@@ -14,8 +14,7 @@ module.exports = function (platform) {
   if (environment !== 'production') {
     notMaster = true;
 
-    requireParam(platform, ['branchToPush']);
-    requireParam(platform, ['confirmPushToMaster']);
+    requireParam(platform, ['branchToPush', 'confirmPushToMaster']);
 
     if (platform.confirmPushToMaster !== 'true') {
       cli.fatal('You must confirm to push to ' + branchToPush + ' to ' + projectName + ' master branch.');

--- a/lib/platforms/heroku.js
+++ b/lib/platforms/heroku.js
@@ -6,18 +6,18 @@ var requireParam = require('../utils/require-param')
 module.exports = function (platform) {
   requireParam(platform, ['projectName'])
 
-  var projectName = platform.projectName;
-  var branchToPush = platform.branchToPush;
-  var environment = platform.environment;
-  var notMaster = false;
+  var projectName = platform.projectName
+  var branchToPush = platform.branchToPush
+  var environment = platform.environment
+  var notMaster = false
 
   if (environment !== 'production') {
-    notMaster = true;
+    notMaster = true
 
-    requireParam(platform, ['branchToPush', 'confirmPushToMaster']);
+    requireParam(platform, ['branchToPush', 'confirmPushToMaster'])
 
     if (platform.confirmPushToMaster !== 'true') {
-      cli.fatal('You must confirm to push to ' + branchToPush + ' to ' + projectName + ' master branch.');
+      cli.fatal('You must confirm to push to ' + branchToPush + ' to ' + projectName + ' master branch.')
     }
   }
 
@@ -30,7 +30,7 @@ module.exports = function (platform) {
     warn('you may need to specify settingsFilePath.')
   }
 
-  var pushCommand = notMaster ? platform.branchToPush + ':master' : 'master';
+  var pushCommand = notMaster ? platform.branchToPush + ':master' : 'master'
 
-  exec('git push heroku ' + pushCommand);
+  exec('git push heroku ' + pushCommand)
 }

--- a/lib/platforms/heroku.js
+++ b/lib/platforms/heroku.js
@@ -7,30 +7,13 @@ module.exports = function (platform) {
   requireParam(platform, ['projectName'])
 
   var projectName = platform.projectName
-  var branchToPush = platform.branchToPush
   var environment = platform.environment
-  var notMaster = false
 
-  if (environment !== 'production') {
-    notMaster = true
-
-    requireParam(platform, ['branchToPush', 'confirmPushToMaster'])
-
-    if (platform.confirmPushToMaster !== 'true') {
-      cli.fatal('You must confirm to push to ' + branchToPush + ' to ' + projectName + ' master branch.')
-    }
-  }
+  exec(`git remote add ${environment} https://git.heroku.com/${projectName}.git &> /dev/null || true`)
 
   if (platform.settingsFilePath) {
-    exec(
-      'heroku config:add' +
-      ' METEOR_SETTINGS="$(cat ' + platform.settingsFilePath + ' | tr -d \'\\n\')"'
-    )
-  } else {
-    warn('you may need to specify settingsFilePath.')
+    exec(`heroku config:set METEOR_SETTINGS="$(cat ${platform.settingsFilePath})`)
   }
 
-  var pushCommand = notMaster ? platform.branchToPush + ':master' : 'master'
-
-  exec('git push heroku ' + pushCommand)
+  exec(`git push ${environment}`)
 }

--- a/lib/platforms/heroku.js
+++ b/lib/platforms/heroku.js
@@ -1,0 +1,40 @@
+var cli = require('cli')
+var exec = require('../utils/exec')
+var warn = require('../utils/warn')
+var requireParam = require('../utils/require-param')
+
+module.exports = function (platform) {
+  requireParam(platform, ['projectName'])
+
+  var projectName = platform.projectName;
+  var branchToPush = platform.branchToPush;
+  var environment = platform.environment;
+  var notMaster = false;
+
+  if (environment !== 'production') {
+    notMaster = true;
+
+    requireParam(platform, ['branchToPush']);
+    requireParam(platform, ['confirmPushToMaster']);
+
+    if (platform.confirmPushToMaster !== 'true') {
+      cli.fatal('You must confirm to push to ' + branchToPush + ' to ' + projectName + ' master branch.');
+    }
+  }
+
+  if (platform.settingsFilePath) {
+    console.log('yo there are settings files.');
+
+    exec(
+      'heroku config:add' +
+      ' METEOR_SETTINGS="$(cat ' + platform.settingsFilePath + ' | tr -d \'\\n\')"'
+    )
+  } else {
+    warn('you may need to specify settingsFilePath.')
+  }
+
+  var pushCommand = notMaster ? platform.branchToPush + ':master' : 'master';
+  console.log('pushCommand: ', pushCommand);
+
+  exec('git push heroku ' + pushCommand);
+}

--- a/lib/platforms/heroku.js
+++ b/lib/platforms/heroku.js
@@ -23,8 +23,6 @@ module.exports = function (platform) {
   }
 
   if (platform.settingsFilePath) {
-    console.log('yo there are settings files.');
-
     exec(
       'heroku config:add' +
       ' METEOR_SETTINGS="$(cat ' + platform.settingsFilePath + ' | tr -d \'\\n\')"'
@@ -34,7 +32,6 @@ module.exports = function (platform) {
   }
 
   var pushCommand = notMaster ? platform.branchToPush + ':master' : 'master';
-  console.log('pushCommand: ', pushCommand);
 
   exec('git push heroku ' + pushCommand);
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "meteor-multi-deploy",
-  "version": "1.0.13",
   "description": "Automate the deployment of a meteor project to multiple platforms. ",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"no test specified\""
+  },
+  "engines": {
+    "node": ">=6.0.0"
   },
   "bin": {
-    "meteor-multi-deploy": "bin/meteor-multi-deploy.js"
+    "meteor-multi-deploy": "bin/meteor-multi-deploy.js",
+    "mmd": "bin/meteor-multi-deploy.js"
   },
   "dependencies": {
     "cli": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Automate the deployment of a meteor project to multiple platforms. ",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"no test specified\""
+    "test": "echo \"no test specified\"",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -35,5 +36,8 @@
   "bugs": {
     "url": "https://github.com/poetic/meteor-multi-deploy/issues"
   },
-  "homepage": "https://github.com/poetic/meteor-multi-deploy"
+  "homepage": "https://github.com/poetic/meteor-multi-deploy",
+  "devDependencies": {
+    "semantic-release": "^4.3.5"
+  }
 }


### PR DESCRIPTION
# Add support for pushing master or branch of choice to Heroku
- Required config in `meteor-multi-deploy.json`
  - If environment is not set to production the config must provide the branch to push and confirm overwrite of master branch on the projects master branch
  - If `settingsFilePath` is provided `heroku config:add` will be executed with provided settings file
- Update README
## Example Heroku config

```
  "platforms": [
    {
      "platformName": "heroku",
      "projectName": "meteor-multi-deploy-setup-production",
      "environment": "production",
      "settingsFilePath": "settings-production.json"
    },
    {
      "platformName": "heroku",
      "projectName": "meteor-multi-deploy-setup-staging",
      "environment": "staging",
      "branchToPush": "staging",
      "confirmPushToMaster": "true",
      "settingsFilePath": "settings-staging.json"
    }
  ]
```
